### PR TITLE
Add stage count configuration

### DIFF
--- a/app/actions/generate-game.ts
+++ b/app/actions/generate-game.ts
@@ -15,6 +15,7 @@ interface StageSpec {
 // Generate specifications for a stage using GPT-4o
 async function generateStageSpec(
   stageNumber: number,
+  stageCount: number,
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
@@ -28,9 +29,12 @@ async function generateStageSpec(
       "Final polish with optimizations and special effects",
     ]
 
-    let prompt = `You are an expert HTML5 game designer creating specifications for a web-based game. 
+    const description =
+      stageDescriptions[stageNumber] || "Additional enhancements and refinement"
+
+    let prompt = `You are an expert HTML5 game designer creating specifications for a web-based game.
 The game theme is: ${theme}.
-This is stage ${stageNumber + 1} of 5: ${stageDescriptions[stageNumber]}.
+This is stage ${stageNumber + 1} of ${stageCount}: ${description}.
 
 Please create detailed specifications for this stage of the game development. These specifications will be used to guide the actual code implementation.
 `
@@ -173,6 +177,7 @@ Focus on making the game fun and engaging for players.`
 // Main function to generate a game stage
 export async function generateGameStage(
   stageNumber: number,
+  stageCount: number,
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
@@ -192,7 +197,7 @@ export async function generateGameStage(
   try {
     // Step 1: Generate specifications for this stage using GPT-4o
     console.log(`Generating specifications for stage ${stageNumber + 1}...`)
-    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey)
+    const stageSpec = await generateStageSpec(stageNumber, stageCount, theme, previousStages, apiKey)
     console.log("Stage specifications generated:", stageSpec)
 
     // Step 2: Use the specifications to generate the actual game code using GPT-4o
@@ -200,7 +205,7 @@ export async function generateGameStage(
 
     let codePrompt = `You are an expert HTML5 game developer creating a web-based game. 
 The game theme is: ${theme}.
-This is stage ${stageNumber + 1} of 5.
+This is stage ${stageNumber + 1} of ${stageCount}.
 
 I'll provide you with detailed specifications for this stage, and you need to implement them in code.
 

--- a/components/pipeline-documentation.tsx
+++ b/components/pipeline-documentation.tsx
@@ -28,8 +28,8 @@ export default function PipelineDocumentation() {
             <h3 className="text-xl font-semibold text-purple-200">Incremental Game Development Process</h3>
 
             <p>
-              This application builds a game through five progressive stages, with each stage building upon the previous
-              one. The process uses a two-step approach for each stage:
+              This application builds a game through a configurable number of progressive stages (five by default), with
+              each stage building upon the previous one. The process uses a two-step approach for each stage:
             </p>
 
             <ol className="list-decimal pl-5 space-y-1">
@@ -96,7 +96,7 @@ export default function PipelineDocumentation() {
               </li>
               <li>Review the generated code, documentation, and preview the game.</li>
               <li>Generate the next stage, which builds upon the previous stage.</li>
-              <li>Continue through all five stages to complete your game.</li>
+              <li>Continue through all configured stages to complete your game.</li>
               <li>
                 Open the game in a new tab for the best playing experience, or use the "Fix Game" button if you
                 encounter rendering issues.


### PR DESCRIPTION
## Summary
- allow generation flow to use a custom number of stages
- persist `stageCount` setting in localStorage
- update prompts and documentation accordingly

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `npx tsc -p tsconfig.json` *(fails: fixedGame.md is possibly 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_683fb65d35a48324bda7d505878544e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to customize the number of game stages, allowing users to specify their preferred stage count instead of being limited to five.
  - Introduced a numeric input in the interface for setting the desired number of stages before starting game generation.

- **Documentation**
  - Updated instructions and descriptions to reflect that the number of game stages is now configurable, with five as the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->