### PR TITLE
Enable custom stage instructions

### DIFF
--- a/app/actions/generate-game.ts
+++ b/app/actions/generate-game.ts
@@ -17,6 +17,7 @@ async function generateStageSpec(
   stageNumber: number,
   theme: string,
   previousStages: GameStageData[],
+  additionalInstructions: string,
   apiKey: string,
 ): Promise<StageSpec> {
   try {
@@ -46,6 +47,10 @@ Please create detailed specifications for this stage of the game development. Th
       }
 
       prompt += `\nCreate specifications that build upon this foundation and enhance the game for stage ${stageNumber + 1}.`
+    }
+
+    if (additionalInstructions && additionalInstructions.trim().length > 0) {
+      prompt += `\nUser provided additional instructions for this stage:\n${additionalInstructions}\nPlease incorporate these requests into the specifications.`
     }
 
     // Stage-specific guidance
@@ -175,6 +180,7 @@ export async function generateGameStage(
   stageNumber: number,
   theme: string,
   previousStages: GameStageData[],
+  additionalInstructions: string,
   apiKey: string,
 ): Promise<GameStageData> {
   if (!apiKey || typeof apiKey !== "string") {
@@ -192,7 +198,13 @@ export async function generateGameStage(
   try {
     // Step 1: Generate specifications for this stage using GPT-4o
     console.log(`Generating specifications for stage ${stageNumber + 1}...`)
-    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey)
+    const stageSpec = await generateStageSpec(
+      stageNumber,
+      theme,
+      previousStages,
+      additionalInstructions,
+      apiKey,
+    )
     console.log("Stage specifications generated:", stageSpec)
 
     // Step 2: Use the specifications to generate the actual game code using GPT-4o
@@ -221,6 +233,8 @@ ${stageSpec.userExperience.map((ux) => `- ${ux}`).join("\n")}
 
 Improvements Over Previous Stage:
 ${stageSpec.improvements.map((imp) => `- ${imp}`).join("\n")}
+
+${additionalInstructions && additionalInstructions.trim().length > 0 ? `User Additional Instructions:\n${additionalInstructions}` : ""}
 
 IMPORTANT BROWSER COMPATIBILITY REQUIREMENTS:
 1. The game MUST work properly when embedded in an iframe AND when opened in a new browser window

--- a/components/game-generator.tsx
+++ b/components/game-generator.tsx
@@ -45,6 +45,7 @@ export default function GameGenerator() {
   const [logs, setLogs] = useState<string[]>([])
   const finalGameIframeRef = useRef<HTMLIFrameElement>(null)
   const [isOpeningNewTab, setIsOpeningNewTab] = useState(false)
+  const [additionalInstructions, setAdditionalInstructions] = useState("")
 
   // Load saved games from localStorage on component mount
   useEffect(() => {
@@ -126,7 +127,13 @@ export default function GameGenerator() {
     setErrorMessage(null)
 
     try {
-      const newStage = await generateGameStage(currentStage, gameTheme || themeInput, stages, apiKey)
+      const newStage = await generateGameStage(
+        currentStage,
+        gameTheme || themeInput,
+        stages,
+        additionalInstructions,
+        apiKey,
+      )
 
       // Check if the stage has an error title
       if (newStage.title.includes("Error") || newStage.title.includes("API Key Missing")) {
@@ -149,6 +156,7 @@ export default function GameGenerator() {
         setIframeError(null)
         setLogs([])
         setRefreshKey((prev) => prev + 1)
+        setAdditionalInstructions("")
       }
     } catch (error: any) {
       console.error("Error generating game stage:", error)
@@ -610,6 +618,17 @@ export default function GameGenerator() {
               </div>
             )}
           </div>
+
+          {currentStage < 5 && (
+            <div className="mt-6">
+              <Textarea
+                placeholder="Additional instructions for the next stage (optional)"
+                value={additionalInstructions}
+                onChange={(e) => setAdditionalInstructions(e.target.value)}
+                className="min-h-[80px]"
+              />
+            </div>
+          )}
         </Card>
       )}
 


### PR DESCRIPTION
## Summary
- support user-provided instructions when generating new stages
- clear instructions after each stage
- show an optional textarea for entering instructions

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff0a4fc988324af632b0d021a6e91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an input area for users to provide additional instructions when generating new game stages.
  - User-provided instructions are now incorporated into both the stage specification and game code generation processes.

- **Bug Fixes**
  - Additional instructions are reset after each stage generation or when the game generator is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->