### PR TITLE
Add customizable stages and template workflow

### DIFF
--- a/components/game-stage.tsx
+++ b/components/game-stage.tsx
@@ -4,15 +4,24 @@ interface GameStageProps {
   stageNumber: number
   stageData: any
   isLatest: boolean
+  onRevert?: () => void
 }
 
-export default function GameStage({ stageNumber, stageData, isLatest }: GameStageProps) {
+export default function GameStage({ stageNumber, stageData, isLatest, onRevert }: GameStageProps) {
   return (
     <div className="border rounded-md p-4 bg-white/5 border-white/10">
       <h3 className="text-xl font-semibold text-white mb-2">
         Stage {stageNumber}: {stageData.title}
       </h3>
       <p className="text-purple-200 mb-4">{stageData.description}</p>
+      {!isLatest && onRevert && (
+        <button
+          onClick={onRevert}
+          className="text-sm text-purple-300 hover:text-white underline"
+        >
+          Revert to this stage
+        </button>
+      )}
     </div>
   )
 }

--- a/components/pipeline-documentation.tsx
+++ b/components/pipeline-documentation.tsx
@@ -31,6 +31,11 @@ export default function PipelineDocumentation() {
               This application builds a game through five progressive stages, with each stage building upon the previous
               one. The process uses a two-step approach for each stage:
             </p>
+            <p className="text-purple-200">
+              You can customize the number of stages, provide per-stage instructions, select a starting template, and
+              choose which AI model to use. After each stage you can add feedback that will be incorporated into the next
+              generation.
+            </p>
 
             <ol className="list-decimal pl-5 space-y-1">
               <li>
@@ -140,6 +145,7 @@ export default function PipelineDocumentation() {
                 <li>Check the "Logs" tab to see console output and debug information</li>
                 <li>Read the "Documentation" tab to understand how your game works</li>
                 <li>Use the "Show Debug Panel" button to see real-time console logs while playing</li>
+                <li>Use the Export/Import buttons to share your game stages with others</li>
               </ul>
             </div>
 

--- a/components/template-selector.tsx
+++ b/components/template-selector.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { useState } from "react"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { templates, GameTemplate } from "@/lib/templates"
+
+interface TemplateSelectorProps {
+  onSelect: (template: GameTemplate | null) => void
+}
+
+export default function TemplateSelector({ onSelect }: TemplateSelectorProps) {
+  const [selected, setSelected] = useState<string>("")
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-white text-lg font-semibold">Choose a Starting Template (optional)</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {templates.map((t) => (
+          <Card
+            key={t.id}
+            className={`p-4 cursor-pointer bg-white/5 border-white/10 ${selected === t.id ? "border-purple-500" : ""}`}
+            onClick={() => {
+              setSelected(t.id)
+              onSelect(t)
+            }}
+          >
+            <h4 className="text-white font-medium mb-1">{t.title}</h4>
+            <p className="text-purple-200 text-sm">{t.description}</p>
+          </Card>
+        ))}
+      </div>
+      <Button variant="outline" className="mt-2" onClick={() => {setSelected(""); onSelect(null)}}>
+        No Template
+      </Button>
+    </div>
+  )
+}

--- a/lib/game-utils.ts
+++ b/lib/game-utils.ts
@@ -117,3 +117,14 @@ export function decompressGameData(compressedData: string): GameStageData {
     throw new Error("Failed to decompress game data")
   }
 }
+
+// Compress an array of stages
+export function compressStages(stages: GameStageData[]): string {
+  return btoa(encodeURIComponent(JSON.stringify(stages)))
+}
+
+// Decompress an array of stages
+export function decompressStages(data: string): GameStageData[] {
+  const decoded = decodeURIComponent(atob(data))
+  return JSON.parse(decoded) as GameStageData[]
+}

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,0 +1,27 @@
+export interface GameTemplate {
+  id: string;
+  title: string;
+  description: string;
+  html: string;
+  css: string;
+  js: string;
+}
+
+export const templates: GameTemplate[] = [
+  {
+    id: "clicker",
+    title: "Classic Clicker",
+    description: "Simple clicker game to increment a counter.",
+    html: `<div id="game-container"><button id="click-btn">Click Me</button><p id="count">0</p></div>`,
+    css: `#game-container{display:flex;flex-direction:column;align-items:center;margin-top:50px;}#click-btn{padding:10px 20px;font-size:20px;}#count{margin-top:10px;font-size:24px;}`,
+    js: `document.addEventListener('DOMContentLoaded',function(){let count=0;const btn=document.getElementById('click-btn');const p=document.getElementById('count');btn.addEventListener('click',function(){count++;p.textContent=String(count);});});`,
+  },
+  {
+    id: "idle",
+    title: "Idle Resource",
+    description: "Generates resources over time with upgrades.",
+    html: `<div id="game-container"><p id="resources">0</p><button id="upgrade">Upgrade (cost 10)</button></div>`,
+    css: `#game-container{display:flex;flex-direction:column;align-items:center;margin-top:50px;}#upgrade{margin-top:10px;}`,
+    js: `document.addEventListener('DOMContentLoaded',function(){let resources=0;let rate=1;const p=document.getElementById('resources');const up=document.getElementById('upgrade');function tick(){resources+=rate;p.textContent=String(resources);requestAnimationFrame(tick);}tick();up.addEventListener('click',function(){if(resources>=10){resources-=10;rate++;}});});`,
+  },
+];


### PR DESCRIPTION
## Summary
- add template selector and built-in templates
- allow choosing model, stages and per-stage instructions
- implement offline mode and feedback loop in generation actions
- support exporting and importing game stages
- enhance documentation with new workflow info

## Testing
- `npm run lint` *(fails: Next.js plugin warning)*

------
https://chatgpt.com/codex/tasks/task_e_683ff0e53580832488d588f3b3856eb0