### PR TITLE
Support custom stage counts

### DIFF
--- a/app/actions/generate-game.ts
+++ b/app/actions/generate-game.ts
@@ -18,6 +18,7 @@ async function generateStageSpec(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  stageCount: number,
 ): Promise<StageSpec> {
   try {
     const stageDescriptions = [
@@ -28,9 +29,9 @@ async function generateStageSpec(
       "Final polish with optimizations and special effects",
     ]
 
-    let prompt = `You are an expert HTML5 game designer creating specifications for a web-based game. 
+    let prompt = `You are an expert HTML5 game designer creating specifications for a web-based game.
 The game theme is: ${theme}.
-This is stage ${stageNumber + 1} of 5: ${stageDescriptions[stageNumber]}.
+This is stage ${stageNumber + 1} of ${stageCount}: ${stageDescriptions[stageNumber] ?? "Additional improvements and features"}.
 
 Please create detailed specifications for this stage of the game development. These specifications will be used to guide the actual code implementation.
 `
@@ -52,63 +53,70 @@ Please create detailed specifications for this stage of the game development. Th
     switch (stageNumber) {
       case 0:
         prompt += `\nFor this first stage, focus on:
-- Basic game structure and core mechanics
-- Essential UI elements and controls
-- Fundamental gameplay loop
-- Visual identity related to the theme
-- Responsive design that works in iframe environments
-- Ensure the game is playable and fun even at this early stage
-- Make sure all game elements are visible and properly positioned
-- Use console.log statements to help with debugging
-- Ensure the game initializes properly with DOMContentLoaded`
+        - Basic game structure and core mechanics
+        - Essential UI elements and controls
+        - Fundamental gameplay loop
+        - Visual identity related to the theme
+        - Responsive design that works in iframe environments
+        - Ensure the game is playable and fun even at this early stage
+        - Make sure all game elements are visible and properly positioned
+        - Use console.log statements to help with debugging
+        - Ensure the game initializes properly with DOMContentLoaded`
         break
       case 1:
         prompt += `\nFor this second stage, focus on:
-- Enhanced game mechanics with more depth
-- Improved user interactions and controls
-- Game progression systems
-- Additional visual elements and feedback
-- Better responsiveness and mobile support
-- Ensure all core gameplay elements are fully implemented
-- Make sure all game elements are visible and properly positioned
-- Use console.log statements to help with debugging
-- Ensure the game initializes properly with DOMContentLoaded`
+        - Enhanced game mechanics with more depth
+        - Improved user interactions and controls
+        - Game progression systems
+        - Additional visual elements and feedback
+        - Better responsiveness and mobile support
+        - Ensure all core gameplay elements are fully implemented
+        - Make sure all game elements are visible and properly positioned
+        - Use console.log statements to help with debugging
+        - Ensure the game initializes properly with DOMContentLoaded`
         break
       case 2:
         prompt += `\nFor this third stage, focus on:
-- Complete game mechanics and systems
-- Polished user interface with clear feedback
-- Full game loop (start, play, end/restart)
-- Refined visuals with animations
-- Sound effects or visual cues for important actions
-- The game should feel complete and polished at this stage
-- Make sure all game elements are visible and properly positioned
-- Use console.log statements to help with debugging
-- Ensure the game initializes properly with DOMContentLoaded`
+        - Complete game mechanics and systems
+        - Polished user interface with clear feedback
+        - Full game loop (start, play, end/restart)
+        - Refined visuals with animations
+        - Sound effects or visual cues for important actions
+        - The game should feel complete and polished at this stage
+        - Make sure all game elements are visible and properly positioned
+        - Use console.log statements to help with debugging
+        - Ensure the game initializes properly with DOMContentLoaded`
         break
       case 3:
-        prompt += `\nFor this fourth stage, focus on:
-- Advanced game mechanics or algorithms
-- Sophisticated scoring or achievement systems
-- Special effects or advanced animations
-- Additional game modes or challenges
-- Enhanced user experience features
-- Take the game beyond the basics with more sophisticated features
-- Make sure all game elements are visible and properly positioned
-- Use console.log statements to help with debugging
-- Ensure the game initializes properly with DOMContentLoaded`
-        break
-      case 4:
-        prompt += `\nFor this final stage, focus on:
-- Final visual polish and special effects
-- Performance optimizations
-- Easter eggs or special features
-- Final balance adjustments
-- Any missing quality-of-life features
-- Perfect the game experience with those final touches that make it special
-- Make sure all game elements are visible and properly positioned
-- Use console.log statements to help with debugging
-- Ensure the game initializes properly with DOMContentLoaded`
+        if (stageCount > 4) {
+          prompt += `\nFor this fourth stage, focus on:
+          - Advanced game mechanics or algorithms
+          - Sophisticated scoring or achievement systems
+          - Special effects or advanced animations
+          - Additional game modes or challenges
+          - Enhanced user experience features
+          - Take the game beyond the basics with more sophisticated features
+          - Make sure all game elements are visible and properly positioned
+          - Use console.log statements to help with debugging
+          - Ensure the game initializes properly with DOMContentLoaded`
+          break
+        }
+        // fall through for generic or final stages
+      default:
+        if (stageNumber === stageCount - 1) {
+          prompt += `\nFor this final stage, focus on:
+          - Final visual polish and special effects
+          - Performance optimizations
+          - Easter eggs or special features
+          - Final balance adjustments
+          - Any missing quality-of-life features
+          - Perfect the game experience with those final touches that make it special
+          - Make sure all game elements are visible and properly positioned
+          - Use console.log statements to help with debugging
+          - Ensure the game initializes properly with DOMContentLoaded`
+        } else {
+          prompt += `\nFor this stage, focus on adding new features and improvements that build upon the previous stages.`
+        }
         break
     }
 
@@ -176,6 +184,7 @@ export async function generateGameStage(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  stageCount: number,
 ): Promise<GameStageData> {
   if (!apiKey || typeof apiKey !== "string") {
     return {
@@ -192,7 +201,7 @@ export async function generateGameStage(
   try {
     // Step 1: Generate specifications for this stage using GPT-4o
     console.log(`Generating specifications for stage ${stageNumber + 1}...`)
-    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey)
+    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey, stageCount)
     console.log("Stage specifications generated:", stageSpec)
 
     // Step 2: Use the specifications to generate the actual game code using GPT-4o
@@ -200,7 +209,7 @@ export async function generateGameStage(
 
     let codePrompt = `You are an expert HTML5 game developer creating a web-based game. 
 The game theme is: ${theme}.
-This is stage ${stageNumber + 1} of 5.
+This is stage ${stageNumber + 1} of ${stageCount}.
 
 I'll provide you with detailed specifications for this stage, and you need to implement them in code.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   title: "Incremental Game Generator",
-  description: "Watch as AI builds a game through five progressive iterations",
+  description: "Watch as AI builds a game through multiple progressive iterations",
   icons: {
     icon: [{ url: "/icon.png", sizes: "32x32", type: "image/png" }],
     apple: [{ url: "/apple-icon.png", sizes: "180x180", type: "image/png" }],

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Incremental Game Generator",
   "short_name": "Game Gen",
-  "description": "Watch as AI builds a game through five progressive iterations",
+  "description": "Watch as AI builds a game through multiple progressive iterations",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#4c1d95",

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -31,7 +31,7 @@ export default async function Image() {
       }}
     >
       <div style={{ fontSize: 64, fontWeight: "bold", marginBottom: 20 }}>Incremental Game Generator</div>
-      <div style={{ fontSize: 32, opacity: 0.8 }}>Watch AI build a game through five progressive iterations</div>
+      <div style={{ fontSize: 32, opacity: 0.8 }}>Watch AI build a game through multiple progressive iterations</div>
     </div>,
     // ImageResponse options
     {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
         <header className="text-center mb-8 sm:mb-12">
           <h1 className="text-3xl sm:text-4xl md:text-6xl font-bold text-white mb-4">Incremental Game Generator</h1>
           <p className="text-lg sm:text-xl text-purple-200 max-w-2xl mx-auto">
-            Watch as AI builds a game through five progressive iterations, each one adding new features and complexity
+            Watch as AI builds a game through multiple progressive iterations, each one adding new features and complexity
           </p>
         </header>
 

--- a/components/pipeline-documentation.tsx
+++ b/components/pipeline-documentation.tsx
@@ -28,8 +28,8 @@ export default function PipelineDocumentation() {
             <h3 className="text-xl font-semibold text-purple-200">Incremental Game Development Process</h3>
 
             <p>
-              This application builds a game through five progressive stages, with each stage building upon the previous
-              one. The process uses a two-step approach for each stage:
+              This application builds a game through a customizable number of progressive stages (five by default), with
+              each stage building upon the previous one. The process uses a two-step approach for each stage:
             </p>
 
             <ol className="list-decimal pl-5 space-y-1">
@@ -96,7 +96,7 @@ export default function PipelineDocumentation() {
               </li>
               <li>Review the generated code, documentation, and preview the game.</li>
               <li>Generate the next stage, which builds upon the previous stage.</li>
-              <li>Continue through all five stages to complete your game.</li>
+              <li>Continue through all stages to complete your game.</li>
               <li>
                 Open the game in a new tab for the best playing experience, or use the "Fix Game" button if you
                 encounter rendering issues.


### PR DESCRIPTION
## Summary
- make total stages configurable and persist setting
- adjust prompts to reference custom total
- update UI with stage input and dynamic progress
- refresh docs and metadata

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684019027e988324a6d30f826893c610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for customizing the number of game generation stages (from 1 to 10) instead of a fixed five stages.
	- Introduced an input field allowing users to specify their preferred number of stages for game creation.

- **Bug Fixes**
	- UI elements such as progress bars, stage counters, and button labels now accurately reflect the chosen number of stages.

- **Documentation**
	- Updated in-app text and documentation to describe the new flexible stage count, replacing references to a fixed five-stage process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->