### PR TITLE
Add stage count customization

### DIFF
--- a/app/actions/generate-game.ts
+++ b/app/actions/generate-game.ts
@@ -18,6 +18,7 @@ async function generateStageSpec(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  totalStages: number,
 ): Promise<StageSpec> {
   try {
     const stageDescriptions = [
@@ -30,7 +31,7 @@ async function generateStageSpec(
 
     let prompt = `You are an expert HTML5 game designer creating specifications for a web-based game. 
 The game theme is: ${theme}.
-This is stage ${stageNumber + 1} of 5: ${stageDescriptions[stageNumber]}.
+This is stage ${stageNumber + 1} of ${totalStages}: ${stageDescriptions[stageNumber] ?? "Additional enhancements"}.
 
 Please create detailed specifications for this stage of the game development. These specifications will be used to guide the actual code implementation.
 `
@@ -176,6 +177,7 @@ export async function generateGameStage(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  totalStages: number,
 ): Promise<GameStageData> {
   if (!apiKey || typeof apiKey !== "string") {
     return {
@@ -192,7 +194,7 @@ export async function generateGameStage(
   try {
     // Step 1: Generate specifications for this stage using GPT-4o
     console.log(`Generating specifications for stage ${stageNumber + 1}...`)
-    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey)
+    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey, totalStages)
     console.log("Stage specifications generated:", stageSpec)
 
     // Step 2: Use the specifications to generate the actual game code using GPT-4o
@@ -200,7 +202,7 @@ export async function generateGameStage(
 
     let codePrompt = `You are an expert HTML5 game developer creating a web-based game. 
 The game theme is: ${theme}.
-This is stage ${stageNumber + 1} of 5.
+This is stage ${stageNumber + 1} of ${totalStages}.
 
 I'll provide you with detailed specifications for this stage, and you need to implement them in code.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   title: "Incremental Game Generator",
-  description: "Watch as AI builds a game through five progressive iterations",
+  description: "Watch as AI builds a game through multiple stages (five by default)",
   icons: {
     icon: [{ url: "/icon.png", sizes: "32x32", type: "image/png" }],
     apple: [{ url: "/apple-icon.png", sizes: "180x180", type: "image/png" }],

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Incremental Game Generator",
   "short_name": "Game Gen",
-  "description": "Watch as AI builds a game through five progressive iterations",
+  "description": "Watch as AI builds a game through multiple stages (five by default)",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#4c1d95",

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -31,7 +31,7 @@ export default async function Image() {
       }}
     >
       <div style={{ fontSize: 64, fontWeight: "bold", marginBottom: 20 }}>Incremental Game Generator</div>
-      <div style={{ fontSize: 32, opacity: 0.8 }}>Watch AI build a game through five progressive iterations</div>
+      <div style={{ fontSize: 32, opacity: 0.8 }}>Watch AI build a game through multiple stages (five by default)</div>
     </div>,
     // ImageResponse options
     {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
         <header className="text-center mb-8 sm:mb-12">
           <h1 className="text-3xl sm:text-4xl md:text-6xl font-bold text-white mb-4">Incremental Game Generator</h1>
           <p className="text-lg sm:text-xl text-purple-200 max-w-2xl mx-auto">
-            Watch as AI builds a game through five progressive iterations, each one adding new features and complexity
+            Watch as AI builds a game through multiple stages (five by default), each one adding new features and complexity
           </p>
         </header>
 

--- a/components/pipeline-documentation.tsx
+++ b/components/pipeline-documentation.tsx
@@ -28,8 +28,8 @@ export default function PipelineDocumentation() {
             <h3 className="text-xl font-semibold text-purple-200">Incremental Game Development Process</h3>
 
             <p>
-              This application builds a game through five progressive stages, with each stage building upon the previous
-              one. The process uses a two-step approach for each stage:
+              This application builds a game through a configurable number of stages (five by default), with each stage
+              building upon the previous one. The process uses a two-step approach for each stage:
             </p>
 
             <ol className="list-decimal pl-5 space-y-1">
@@ -96,7 +96,7 @@ export default function PipelineDocumentation() {
               </li>
               <li>Review the generated code, documentation, and preview the game.</li>
               <li>Generate the next stage, which builds upon the previous stage.</li>
-              <li>Continue through all five stages to complete your game.</li>
+              <li>Continue through all stages to complete your game.</li>
               <li>
                 Open the game in a new tab for the best playing experience, or use the "Fix Game" button if you
                 encounter rendering issues.


### PR DESCRIPTION
## Summary
- add a numeric stage count input and store the value
- persist stage count across sessions and handle reset
- adjust generation pipeline to use the configured count
- update documentation and metadata to mention the default of five stages

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_684019e52e9c8324826076938a8daff3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to configure the number of stages in the game-building process, with five as the default.
  - Introduced a numeric input field allowing users to specify their desired stage count.

- **Bug Fixes**
  - Progress indicators, completion checks, and UI elements now dynamically reflect the selected number of stages.

- **Documentation**
  - Updated all descriptions and help texts to reference a configurable number of stages instead of a fixed five.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->