### PR TITLE
Add optional instructions per stage

### DIFF
--- a/app/actions/generate-game.ts
+++ b/app/actions/generate-game.ts
@@ -18,6 +18,7 @@ async function generateStageSpec(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  instructions?: string,
 ): Promise<StageSpec> {
   try {
     const stageDescriptions = [
@@ -28,12 +29,16 @@ async function generateStageSpec(
       "Final polish with optimizations and special effects",
     ]
 
-    let prompt = `You are an expert HTML5 game designer creating specifications for a web-based game. 
+  let prompt = `You are an expert HTML5 game designer creating specifications for a web-based game.
 The game theme is: ${theme}.
 This is stage ${stageNumber + 1} of 5: ${stageDescriptions[stageNumber]}.
 
 Please create detailed specifications for this stage of the game development. These specifications will be used to guide the actual code implementation.
 `
+
+    if (instructions && instructions.trim().length > 0) {
+      prompt += `\nUser additional instructions for this stage:\n${instructions}\n`
+    }
 
     // Add context from previous stages if they exist
     if (previousStages.length > 0) {
@@ -176,6 +181,7 @@ export async function generateGameStage(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  instructions?: string,
 ): Promise<GameStageData> {
   if (!apiKey || typeof apiKey !== "string") {
     return {
@@ -192,7 +198,7 @@ export async function generateGameStage(
   try {
     // Step 1: Generate specifications for this stage using GPT-4o
     console.log(`Generating specifications for stage ${stageNumber + 1}...`)
-    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey)
+    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey, instructions)
     console.log("Stage specifications generated:", stageSpec)
 
     // Step 2: Use the specifications to generate the actual game code using GPT-4o
@@ -221,6 +227,8 @@ ${stageSpec.userExperience.map((ux) => `- ${ux}`).join("\n")}
 
 Improvements Over Previous Stage:
 ${stageSpec.improvements.map((imp) => `- ${imp}`).join("\n")}
+
+${instructions && instructions.trim().length > 0 ? `Additional User Instructions:\n${instructions}` : ""}
 
 IMPORTANT BROWSER COMPATIBILITY REQUIREMENTS:
 1. The game MUST work properly when embedded in an iframe AND when opened in a new browser window

--- a/components/game-generator.tsx
+++ b/components/game-generator.tsx
@@ -35,6 +35,7 @@ export default function GameGenerator() {
   const [gameTheme, setGameTheme] = useState("")
   const [apiKey, setApiKey] = useState<string | null>(null)
   const [themeInput, setThemeInput] = useState("")
+  const [additionalInstructions, setAdditionalInstructions] = useState("")
   const [showThemeInput, setShowThemeInput] = useState(false)
   const [iframeLoaded, setIframeLoaded] = useState(false)
   const [iframeError, setIframeError] = useState<string | null>(null)
@@ -127,7 +128,13 @@ export default function GameGenerator() {
     setErrorMessage(null)
 
     try {
-      const newStage = await generateGameStage(currentStage, gameTheme || themeInput, stages, apiKey)
+      const newStage = await generateGameStage(
+        currentStage,
+        gameTheme || themeInput,
+        stages,
+        apiKey,
+        additionalInstructions,
+      )
 
       // Check if the stage has an error title
       if (newStage.title.includes("Error") || newStage.title.includes("API Key Missing")) {
@@ -150,12 +157,14 @@ export default function GameGenerator() {
         setIframeError(null)
         setLogs([])
         setRefreshKey((prev) => prev + 1)
+        setAdditionalInstructions("")
       }
     } catch (error: any) {
       console.error("Error generating game stage:", error)
       setErrorMessage(error.message || "Failed to generate game stage. Please check your API key and try again.")
     } finally {
       setIsGenerating(false)
+      setAdditionalInstructions("")
     }
   }
 
@@ -499,6 +508,7 @@ export default function GameGenerator() {
       setIsComplete(false)
       setGameTheme("")
       setShowThemeInput(true)
+      setAdditionalInstructions("")
       localStorage.removeItem("generatedGames")
       localStorage.removeItem("gameTheme")
     }
@@ -564,11 +574,11 @@ export default function GameGenerator() {
               <h2 className="text-2xl font-bold text-white">Game Evolution Pipeline</h2>
               <p className="text-purple-200 text-sm mt-1">Theme: {gameTheme}</p>
               <Progress value={(currentStage / 5) * 100} className="mt-2" />
+          </div>
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <div className="text-purple-200 text-sm whitespace-nowrap">
+              Stage {currentStage}/5 {isComplete ? "(Complete)" : ""}
             </div>
-            <div className="flex items-center gap-2 w-full sm:w-auto">
-              <div className="text-purple-200 text-sm whitespace-nowrap">
-                Stage {currentStage}/5 {isComplete ? "(Complete)" : ""}
-              </div>
               <Button
                 onClick={handleGenerate}
                 disabled={isGenerating || isComplete}
@@ -586,18 +596,29 @@ export default function GameGenerator() {
                 ) : (
                   "Generate Next Stage"
                 )}
-              </Button>
-              <Button
-                onClick={handleReset}
-                variant="outline"
-                className="border-red-500/50 hover:bg-red-700/30 text-red-300 hover:text-red-100"
-              >
-                Reset
-              </Button>
-            </div>
+            </Button>
+            <Button
+              onClick={handleReset}
+              variant="outline"
+              className="border-red-500/50 hover:bg-red-700/30 text-red-300 hover:text-red-100"
+            >
+              Reset
+            </Button>
           </div>
+        </div>
 
-          <div className="space-y-4">
+        {!isComplete && (
+          <div className="mb-4">
+            <Textarea
+              placeholder="Additional instructions for this stage (optional)"
+              value={additionalInstructions}
+              onChange={(e) => setAdditionalInstructions(e.target.value)}
+              className="min-h-[80px]"
+            />
+          </div>
+        )}
+
+        <div className="space-y-4">
             {stages.map((stage, index) => (
               <GameStage key={index} stageNumber={index + 1} stageData={stage} isLatest={index === stages.length - 1} />
             ))}


### PR DESCRIPTION
## Summary
- let the backend accept optional user instructions
- allow entering additional instructions for each stage
- reset additional instructions when generating or resetting

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68401b1de5d883248ed2b0b75c875acf