### PR TITLE
Add user instructions for stage generation

### DIFF
--- a/app/actions/generate-game.ts
+++ b/app/actions/generate-game.ts
@@ -18,6 +18,7 @@ async function generateStageSpec(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  additionalInstructions: string = "",
 ): Promise<StageSpec> {
   try {
     const stageDescriptions = [
@@ -112,6 +113,10 @@ Please create detailed specifications for this stage of the game development. Th
         break
     }
 
+    if (additionalInstructions) {
+      prompt += `\nAdditional User Instructions:\n${additionalInstructions}`
+    }
+
     prompt += `\nReturn your response in the following JSON format:
 {
   "title": "Game Title - Stage ${stageNumber + 1}",
@@ -176,6 +181,7 @@ export async function generateGameStage(
   theme: string,
   previousStages: GameStageData[],
   apiKey: string,
+  additionalInstructions: string = "",
 ): Promise<GameStageData> {
   if (!apiKey || typeof apiKey !== "string") {
     return {
@@ -192,7 +198,13 @@ export async function generateGameStage(
   try {
     // Step 1: Generate specifications for this stage using GPT-4o
     console.log(`Generating specifications for stage ${stageNumber + 1}...`)
-    const stageSpec = await generateStageSpec(stageNumber, theme, previousStages, apiKey)
+    const stageSpec = await generateStageSpec(
+      stageNumber,
+      theme,
+      previousStages,
+      apiKey,
+      additionalInstructions,
+    )
     console.log("Stage specifications generated:", stageSpec)
 
     // Step 2: Use the specifications to generate the actual game code using GPT-4o
@@ -219,8 +231,10 @@ ${stageSpec.technicalRequirements.map((req) => `- ${req}`).join("\n")}
 User Experience Considerations:
 ${stageSpec.userExperience.map((ux) => `- ${ux}`).join("\n")}
 
-Improvements Over Previous Stage:
+    Improvements Over Previous Stage:
 ${stageSpec.improvements.map((imp) => `- ${imp}`).join("\n")}
+
+${additionalInstructions ? `Additional User Instructions:\n${additionalInstructions}\n` : ""}
 
 IMPORTANT BROWSER COMPATIBILITY REQUIREMENTS:
 1. The game MUST work properly when embedded in an iframe AND when opened in a new browser window

--- a/components/game-generator.tsx
+++ b/components/game-generator.tsx
@@ -46,6 +46,7 @@ export default function GameGenerator() {
   const [logs, setLogs] = useState<string[]>([])
   const finalGameIframeRef = useRef<HTMLIFrameElement>(null)
   const [isOpeningNewTab, setIsOpeningNewTab] = useState(false)
+  const [additionalInstructions, setAdditionalInstructions] = useState("")
 
   // Load saved games from localStorage on component mount
   useEffect(() => {
@@ -127,7 +128,13 @@ export default function GameGenerator() {
     setErrorMessage(null)
 
     try {
-      const newStage = await generateGameStage(currentStage, gameTheme || themeInput, stages, apiKey)
+      const newStage = await generateGameStage(
+        currentStage,
+        gameTheme || themeInput,
+        stages,
+        apiKey,
+        additionalInstructions,
+      )
 
       // Check if the stage has an error title
       if (newStage.title.includes("Error") || newStage.title.includes("API Key Missing")) {
@@ -150,6 +157,7 @@ export default function GameGenerator() {
         setIframeError(null)
         setLogs([])
         setRefreshKey((prev) => prev + 1)
+        setAdditionalInstructions("")
       }
     } catch (error: any) {
       console.error("Error generating game stage:", error)
@@ -602,16 +610,27 @@ export default function GameGenerator() {
               <GameStage key={index} stageNumber={index + 1} stageData={stage} isLatest={index === stages.length - 1} />
             ))}
 
-            {stages.length === 0 && (
-              <div className="text-center py-12 text-purple-200">
-                <p className="text-xl mb-4">Ready to build your "{gameTheme}" game!</p>
-                <p>Click the "Generate First Stage" button above to start creating your game.</p>
-                <p className="mt-4 text-sm opacity-70">
-                  Each stage will build upon the previous one, creating a more complex and engaging game.
-                </p>
-              </div>
-            )}
-          </div>
+          {stages.length === 0 && (
+            <div className="text-center py-12 text-purple-200">
+              <p className="text-xl mb-4">Ready to build your "{gameTheme}" game!</p>
+              <p>Click the "Generate First Stage" button above to start creating your game.</p>
+              <p className="mt-4 text-sm opacity-70">
+                Each stage will build upon the previous one, creating a more complex and engaging game.
+              </p>
+            </div>
+          )}
+
+          {!isComplete && (
+            <div>
+              <Textarea
+                placeholder="Additional instructions for the next stage (optional)"
+                value={additionalInstructions}
+                onChange={(e) => setAdditionalInstructions(e.target.value)}
+                className="bg-white/5 border-white/10 text-white"
+              />
+            </div>
+          )}
+        </div>
         </Card>
       )}
 


### PR DESCRIPTION
## Summary
- allow optional custom instructions when generating stages
- reset instructions after each stage
- include custom instructions in backend generation
- add textarea for entering instructions

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68401d53a8f483248a12197852947848