### PR TITLE
Fix build warnings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
   images: {
     domains: ['placeholder.com'],
     unoptimized: true,
@@ -11,13 +10,6 @@ const nextConfig = {
   },
   typescript: {
     ignoreBuildErrors: true,
-  },
-  // Increase the timeout for API routes to handle longer OpenAI requests
-  api: {
-    responseLimit: false,
-    bodyParser: {
-      sizeLimit: '1mb',
-    },
   },
   // Optimize production builds
   compiler: {


### PR DESCRIPTION
## Summary
- remove deprecated `swcMinify` and `api` entries from `next.config.mjs`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684065fc1dd08324bed26933aa87e035