### PR TITLE
Add model selection with fallback

### DIFF
--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
+import { AVAILABLE_MODELS } from "@/lib/openai-utils"
+
+interface ModelSelectorProps {
+  value: string
+  onChange: (model: string) => void
+}
+
+export default function ModelSelector({ value, onChange }: ModelSelectorProps) {
+  return (
+    <div className="min-w-[8rem]">
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="bg-white/5 border-white/10 text-white">
+          <SelectValue placeholder="Model" />
+        </SelectTrigger>
+        <SelectContent>
+          {AVAILABLE_MODELS.map((m) => (
+            <SelectItem key={m} value={m}>
+              {m}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/lib/openai-utils.ts
+++ b/lib/openai-utils.ts
@@ -1,0 +1,46 @@
+export const AVAILABLE_MODELS = [
+  "gpt-4o",
+  "gpt-4-turbo",
+  "gpt-3.5-turbo"
+]
+
+export async function chatCompletionWithFallback({
+  apiKey,
+  messages,
+  model,
+  temperature = 0.7,
+}: {
+  apiKey: string
+  messages: { role: string; content: string }[]
+  model: string
+  temperature?: number
+}) {
+  const tried = new Set<string>()
+  for (const m of [model, ...AVAILABLE_MODELS]) {
+    if (tried.has(m)) continue
+    tried.add(m)
+    try {
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: m,
+          messages,
+          response_format: { type: "json_object" },
+          temperature,
+        }),
+      })
+      if (res.ok) {
+        return await res.json()
+      }
+      const errorData = await res.json().catch(() => ({}))
+      console.error(`OpenAI API error with model ${m}:`, errorData)
+    } catch (err) {
+      console.error(`OpenAI request failed with model ${m}:`, err)
+    }
+  }
+  throw new Error("All models failed to respond")
+}


### PR DESCRIPTION
## Summary
- add OpenAI helper with model fallback
- let users pick a model when generating
- plumb model through generation pipeline

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6840e114b1b883248a32bc0189ee25eb