### PR TITLE
Add network status detection

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Analytics } from "@vercel/analytics/react"
 import ErrorBoundary from "@/components/error-boundary"
+import NetworkIndicator from "@/components/network-indicator"
 import { Suspense } from "react"
 
 // Initialize the Inter font
@@ -31,6 +32,7 @@ export default function RootLayout({
         <Suspense fallback={<div>Loading...</div>}>
           <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
             <ErrorBoundary>{children}</ErrorBoundary>
+            <NetworkIndicator className="fixed bottom-2 right-2 z-50" />
           </ThemeProvider>
           <Analytics />
         </Suspense>

--- a/components/network-indicator.tsx
+++ b/components/network-indicator.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { useNetworkStatus } from "@/hooks/use-network"
+
+interface NetworkIndicatorProps {
+  className?: string
+}
+
+export default function NetworkIndicator({ className }: NetworkIndicatorProps) {
+  const { online, type } = useNetworkStatus()
+
+  const label = online ? `Connected (${type})` : "Offline"
+  const color = online ? "text-green-400" : "text-red-400"
+
+  return <div className={cn("text-xs", color, className)}>{label}</div>
+}

--- a/docs/NETWORK_AUTOSCALING.md
+++ b/docs/NETWORK_AUTOSCALING.md
@@ -1,0 +1,19 @@
+# Network Auto‑Scaling
+
+This project now includes a simple hook for detecting network status so the UI
+can adapt to different connection types. The hook exposes whether the user is
+online and tries to identify the connection type (Wi‑Fi, cellular, ethernet or
+none).
+
+Developers can use `useNetworkStatus` to adjust game behaviour when
+connectivity is poor. For example you might disable heavy animations or switch
+to a low bandwidth mode on cellular connections. The `NetworkIndicator`
+component provides a minimal example of how to display the current status to
+players.
+
+```tsx
+import NetworkIndicator from "@/components/network-indicator"
+```
+
+The indicator is added to the root layout so it appears across the entire
+application. Feel free to reposition or style it differently to suit your needs.

--- a/hooks/use-network.ts
+++ b/hooks/use-network.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect } from "react"
+
+export type ConnectionType =
+  | "wifi"
+  | "cellular"
+  | "ethernet"
+  | "none"
+  | "unknown"
+
+export function useNetworkStatus() {
+  const [online, setOnline] = useState(
+    typeof navigator !== "undefined" ? navigator.onLine : true
+  )
+  const [type, setType] = useState<ConnectionType>("unknown")
+
+  useEffect(() => {
+    function updateOnline() {
+      setOnline(navigator.onLine)
+    }
+
+    window.addEventListener("online", updateOnline)
+    window.addEventListener("offline", updateOnline)
+    updateOnline()
+
+    const connection =
+      (navigator as any).connection ||
+      (navigator as any).mozConnection ||
+      (navigator as any).webkitConnection
+
+    function updateConnection() {
+      if (!connection) return
+      const cType: string = connection.type || connection.effectiveType
+      if (cType.includes("wifi")) setType("wifi")
+      else if (cType.includes("ethernet")) setType("ethernet")
+      else if (cType.includes("cellular") || /\dg/.test(cType)) setType("cellular")
+      else if (cType === "none") setType("none")
+      else setType("unknown")
+    }
+
+    if (connection) {
+      connection.addEventListener("change", updateConnection)
+      updateConnection()
+    }
+
+    return () => {
+      window.removeEventListener("online", updateOnline)
+      window.removeEventListener("offline", updateOnline)
+      if (connection) connection.removeEventListener("change", updateConnection)
+    }
+  }, [])
+
+  return { online, type }
+}
+
+export function getNetworkQuality(type: ConnectionType) {
+  switch (type) {
+    case "none":
+      return "none"
+    case "cellular":
+      return "low"
+    case "wifi":
+    case "ethernet":
+      return "high"
+    default:
+      return "unknown"
+  }
+}


### PR DESCRIPTION
## Summary
- add `useNetworkStatus` hook to track Wi-Fi or cellular connectivity
- show connection status in a new `NetworkIndicator` component
- display the indicator on every page via the root layout
- document network auto-scaling features

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68417f905f50832490d43fcf51391f0c