### PR TITLE
Add foldable view for generated stage code

### DIFF
--- a/components/game-generator.tsx
+++ b/components/game-generator.tsx
@@ -599,7 +599,7 @@ export default function GameGenerator() {
 
           <div className="space-y-4">
             {stages.map((stage, index) => (
-              <GameStage key={index} stageNumber={index + 1} stageData={stage} isLatest={index === stages.length - 1} />
+              <GameStage key={index} stageNumber={index + 1} stageData={stage} />
             ))}
 
             {stages.length === 0 && (

--- a/components/game-stage.tsx
+++ b/components/game-stage.tsx
@@ -1,18 +1,58 @@
 "use client"
 
+import CodeViewer from "./code-viewer"
+import MarkdownRenderer from "./markdown-renderer"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+
 interface GameStageProps {
   stageNumber: number
   stageData: any
-  isLatest: boolean
 }
 
-export default function GameStage({ stageNumber, stageData, isLatest }: GameStageProps) {
+export default function GameStage({ stageNumber, stageData }: GameStageProps) {
   return (
-    <div className="border rounded-md p-4 bg-white/5 border-white/10">
-      <h3 className="text-xl font-semibold text-white mb-2">
-        Stage {stageNumber}: {stageData.title}
-      </h3>
-      <p className="text-purple-200 mb-4">{stageData.description}</p>
-    </div>
+    <Accordion type="single" collapsible className="border rounded-md bg-white/5 border-white/10">
+      <AccordionItem value="stage">
+        <AccordionTrigger className="px-4 py-3 text-left text-xl font-semibold text-white">
+          Stage {stageNumber}: {stageData.title}
+        </AccordionTrigger>
+        <AccordionContent className="space-y-4 p-4">
+          <p className="text-purple-200">{stageData.description}</p>
+          <Accordion type="multiple" className="space-y-2">
+            <AccordionItem value="html">
+              <AccordionTrigger className="text-sm">HTML</AccordionTrigger>
+              <AccordionContent>
+                <CodeViewer code={stageData.html} language="html" />
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="css">
+              <AccordionTrigger className="text-sm">CSS</AccordionTrigger>
+              <AccordionContent>
+                <CodeViewer code={stageData.css} language="css" />
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="js">
+              <AccordionTrigger className="text-sm">JavaScript</AccordionTrigger>
+              <AccordionContent>
+                <CodeViewer code={stageData.js} language="javascript" />
+              </AccordionContent>
+            </AccordionItem>
+            {stageData.md && (
+              <AccordionItem value="docs">
+                <AccordionTrigger className="text-sm">Docs</AccordionTrigger>
+                <AccordionContent>
+                  <MarkdownRenderer content={stageData.md} />
+                </AccordionContent>
+              </AccordionItem>
+            )}
+          </Accordion>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   )
 }


### PR DESCRIPTION
## Summary
- show stage code in collapsible sections using accordion
- update generator to use new `GameStage` API

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417f2d07508324ba73d0f925f2a6d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the stage display with an accordion interface, allowing users to expand and collapse details for each stage.
  - Added separate expandable sections for HTML, CSS, JavaScript code snippets, and stage documentation within each stage.

- **Refactor**
  - Enhanced the layout and organization of stage content for better readability and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->