### PR TITLE
Improve stage view with provider details

### DIFF
--- a/components/game-stage.tsx
+++ b/components/game-stage.tsx
@@ -1,5 +1,11 @@
 "use client"
 
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import CodeViewer from "./code-viewer"
+import MarkdownRenderer from "./markdown-renderer"
+
 interface GameStageProps {
   stageNumber: number
   stageData: any
@@ -7,12 +13,46 @@ interface GameStageProps {
 }
 
 export default function GameStage({ stageNumber, stageData, isLatest }: GameStageProps) {
+  const [expanded, setExpanded] = useState(isLatest)
+
   return (
-    <div className="border rounded-md p-4 bg-white/5 border-white/10">
-      <h3 className="text-xl font-semibold text-white mb-2">
-        Stage {stageNumber}: {stageData.title}
-      </h3>
-      <p className="text-purple-200 mb-4">{stageData.description}</p>
-    </div>
+    <Card className="bg-white/5 border-white/10">
+      <CardHeader className="cursor-pointer" onClick={() => setExpanded(!expanded)}>
+        <CardTitle className="text-white">
+          Stage {stageNumber}: {stageData.title}
+        </CardTitle>
+      </CardHeader>
+      {expanded && (
+        <CardContent className="space-y-4 text-purple-200">
+          <p>{stageData.description}</p>
+          <Tabs defaultValue="preview" className="w-full">
+            <TabsList className="mb-2">
+              <TabsTrigger value="preview">Preview</TabsTrigger>
+              <TabsTrigger value="html">HTML</TabsTrigger>
+              <TabsTrigger value="css">CSS</TabsTrigger>
+              <TabsTrigger value="js">JS</TabsTrigger>
+              {stageData.md && <TabsTrigger value="docs">Docs</TabsTrigger>}
+            </TabsList>
+            <TabsContent value="preview">
+              <div dangerouslySetInnerHTML={{ __html: stageData.html }} />
+            </TabsContent>
+            <TabsContent value="html">
+              <CodeViewer code={stageData.html} language="html" />
+            </TabsContent>
+            <TabsContent value="css">
+              <CodeViewer code={stageData.css} language="css" />
+            </TabsContent>
+            <TabsContent value="js">
+              <CodeViewer code={stageData.js} language="javascript" />
+            </TabsContent>
+            {stageData.md && (
+              <TabsContent value="docs">
+                <MarkdownRenderer content={stageData.md} />
+              </TabsContent>
+            )}
+          </Tabs>
+        </CardContent>
+      )}
+    </Card>
   )
 }


### PR DESCRIPTION
## Summary
- show detailed provider results for each stage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68417efd885c832483d575678347bb53