### PR TITLE
Add theme toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
+import ThemeToggle from "@/components/theme-toggle"
 import { Analytics } from "@vercel/analytics/react"
 import ErrorBoundary from "@/components/error-boundary"
 import { Suspense } from "react"
@@ -31,6 +32,9 @@ export default function RootLayout({
         <Suspense fallback={<div>Loading...</div>}>
           <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
             <ErrorBoundary>{children}</ErrorBoundary>
+            <div className="fixed top-4 right-4 z-50">
+              <ThemeToggle />
+            </div>
           </ThemeProvider>
           <Analytics />
         </Suspense>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useTheme } from "next-themes"
+import { Moon, Sun } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  const isDark = theme === "dark"
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a theme toggle component
- show the toggle in the global layout for quick switching

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68417e25944083248b0b35d375e386ad