### PR TITLE
Improve effect hooks

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -325,7 +325,7 @@ export default function GamePage() {
         console.log = console.log.__proto__.log || console.log
       }
     }
-  }, [gameData, showDebug, threeJsLoaded, activeTab])
+  }, [gameData, showDebug, threeJsLoaded, activeTab, gameLoaded])
 
   // Listen for messages from the game
   useEffect(() => {

--- a/components/api-key-form.tsx
+++ b/components/api-key-form.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
@@ -20,18 +20,7 @@ export default function ApiKeyForm({ onApiKeyValidated }: ApiKeyFormProps) {
   const [validationError, setValidationError] = useState<string | null>(null)
   const [isValid, setIsValid] = useState(false)
 
-  // Check for saved API key on component mount
-  useEffect(() => {
-    const storedApiKey = localStorage.getItem("openai_api_key")
-    if (storedApiKey) {
-      setSavedApiKey(storedApiKey)
-      setApiKey(storedApiKey)
-      // Auto-validate the stored key
-      handleValidateApiKey(storedApiKey)
-    }
-  }, [])
-
-  const handleValidateApiKey = async (keyToValidate: string) => {
+  const handleValidateApiKey = useCallback(async (keyToValidate: string) => {
     if (!keyToValidate || typeof keyToValidate !== "string" || !keyToValidate.startsWith("sk-")) {
       setValidationError("Invalid API key format. API keys should start with 'sk-'")
       return
@@ -59,7 +48,19 @@ export default function ApiKeyForm({ onApiKeyValidated }: ApiKeyFormProps) {
     } finally {
       setIsValidating(false)
     }
-  }
+  }, [onApiKeyValidated])
+
+  // Check for saved API key on component mount
+  useEffect(() => {
+    const storedApiKey = localStorage.getItem("openai_api_key")
+    if (storedApiKey) {
+      setSavedApiKey(storedApiKey)
+      setApiKey(storedApiKey)
+      // Auto-validate the stored key
+      handleValidateApiKey(storedApiKey)
+    }
+  }, [handleValidateApiKey])
+
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()

--- a/components/game-generator.tsx
+++ b/components/game-generator.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { generateGameStage, fixGameCode } from "@/app/actions/generate-game"
@@ -60,15 +60,12 @@ export default function GameGenerator() {
       if (storedGames) {
         const games = JSON.parse(storedGames)
         if (Array.isArray(games) && games.length > 0) {
-          // Only load the games if we don't already have stages
-          if (stages.length === 0) {
-            setStages(games)
-            setCurrentStage(games.length)
-            setGameTheme(localStorage.getItem("gameTheme") || "")
-            setShowThemeInput(false)
-            if (games.length === 5) {
-              setIsComplete(true)
-            }
+          setStages(games)
+          setCurrentStage(games.length)
+          setGameTheme(localStorage.getItem("gameTheme") || "")
+          setShowThemeInput(false)
+          if (games.length === 5) {
+            setIsComplete(true)
           }
         } else if (storedApiKey) {
           // If we have an API key but no games, show the theme input
@@ -253,7 +250,7 @@ export default function GameGenerator() {
   }
 
   // Generate iframe content with proper error handling
-  const generateFinalGameIframeContent = () => {
+  const generateFinalGameIframeContent = useCallback(() => {
     if (stages.length === 0) return ""
 
     const latestStage = stages[stages.length - 1]
@@ -457,7 +454,7 @@ export default function GameGenerator() {
       </body>
       </html>
     `
-  }
+  }, [stages])
 
   // Set up message listener for iframe communication
   useEffect(() => {
@@ -489,7 +486,7 @@ export default function GameGenerator() {
       setLogs([])
       finalGameIframeRef.current.srcdoc = generateFinalGameIframeContent()
     }
-  }, [stages, refreshKey])
+  }, [stages, refreshKey, generateFinalGameIframeContent])
 
   // Function to reset the game generator
   const handleReset = () => {


### PR DESCRIPTION
## Summary
- sync `gameLoaded` state in game page effect
- make API key validation stable and re-usable
- memoize final game iframe HTML generation and clean initial load logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417e9f43a083249b355cb7caddc105