### PR TITLE
Simplify game embed logic

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -7,6 +7,7 @@ import Script from "next/script"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import ReactMarkdown from "react-markdown"
+import { getGameStyles } from "@/lib/game-utils"
 
 // Simple syntax highlighting component
 function CodeBlock({ code, language }: { code: string; language: string }) {
@@ -123,56 +124,7 @@ export default function GamePage() {
 
     // Add the CSS
     const styleElement = document.createElement("style")
-    styleElement.textContent = `
-      html, body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        font-family: 'Arial', sans-serif;
-        background-color: white;
-      }
-      #game-container {
-        width: 100%;
-        height: 100%;
-        overflow: auto;
-        position: relative;
-        background-color: white;
-        color: black;
-      }
-      #error-display {
-        position: fixed;
-        bottom: 10px;
-        right: 10px;
-        background: rgba(255,0,0,0.8);
-        color: white;
-        padding: 10px;
-        border-radius: 5px;
-        font-family: monospace;
-        z-index: 9999;
-        max-width: 80%;
-        word-break: break-word;
-      }
-      #debug-panel {
-        position: fixed;
-        top: 0;
-        right: 0;
-        background: rgba(0,0,0,0.7);
-        color: white;
-        padding: 5px;
-        font-family: monospace;
-        font-size: 10px;
-        z-index: 9999;
-        max-width: 300px;
-        max-height: 200px;
-        overflow: auto;
-      }
-      * {
-        box-sizing: border-box;
-      }
-      ${gameData.css}
-    `
+    styleElement.textContent = getGameStyles(gameData.css)
     document.head.appendChild(styleElement)
 
     // Set up console log capture

--- a/lib/game-utils.ts
+++ b/lib/game-utils.ts
@@ -117,3 +117,58 @@ export function decompressGameData(compressedData: string): GameStageData {
     throw new Error("Failed to decompress game data")
   }
 }
+
+// Base styles used for game previews and pages
+export function getGameStyles(extraCss = "", hideDebugPanel = false): string {
+  return `
+      html, body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        font-family: 'Arial', sans-serif;
+        background-color: white;
+      }
+      #game-container {
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+        position: relative;
+        background-color: white;
+        color: black;
+      }
+      #error-display {
+        position: fixed;
+        bottom: 10px;
+        right: 10px;
+        background: rgba(255,0,0,0.8);
+        color: white;
+        padding: 10px;
+        border-radius: 5px;
+        font-family: monospace;
+        z-index: 9999;
+        max-width: 80%;
+        word-break: break-word;
+      }
+      #debug-panel {
+        position: fixed;
+        top: 0;
+        right: 0;
+        background: rgba(0,0,0,0.7);
+        color: white;
+        padding: 5px;
+        font-family: monospace;
+        font-size: 10px;
+        z-index: 9999;
+        max-width: 300px;
+        max-height: 200px;
+        overflow: auto;
+        ${hideDebugPanel ? "display: none;" : ""}
+      }
+      * {
+        box-sizing: border-box;
+      }
+      ${extraCss}
+    `
+}


### PR DESCRIPTION
## Summary
- centralize default game styles in `game-utils`
- use new helper in game pages and generator
- simplify new tab logic with `saveGame` and `compressGameData`

## Testing
- `pnpm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843a145031483248a63acf60637d593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved maintainability by centralizing game style generation into a utility function, reducing inline CSS and simplifying style management.
	- Streamlined game data saving and compression by utilizing dedicated utility functions.
- **New Features**
	- Added support for dynamic game styles and conditional debug panel visibility in game previews and pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->